### PR TITLE
feat: Partial setup for Laravel Breeze installation

### DIFF
--- a/vendaaki/.env.example
+++ b/vendaaki/.env.example
@@ -1,66 +1,93 @@
-APP_NAME=Laravel
+APP_NAME=VendaAki
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_TIMEZONE=UTC
 APP_URL=http://localhost
-
-APP_LOCALE=en
-APP_FALLBACK_LOCALE=en
-APP_FAKER_LOCALE=en_US
-
-APP_MAINTENANCE_DRIVER=file
-# APP_MAINTENANCE_STORE=database
-
-PHP_CLI_SERVER_WORKERS=4
-
-BCRYPT_ROUNDS=12
+APP_TIMEZONE=UTC
 
 LOG_CHANNEL=stack
-LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
-DB_CONNECTION=sqlite
-# DB_HOST=127.0.0.1
-# DB_PORT=3306
-# DB_DATABASE=laravel
-# DB_USERNAME=root
-# DB_PASSWORD=
+# --------------------------------------------------------------------------
+# Database Configuration
+# --------------------------------------------------------------------------
+# Option 1: SQLite (Recommended for quick local testing or sandbox environments)
+# To use, uncomment DB_CONNECTION=sqlite and ensure DB_DATABASE is empty or points to your .sqlite file.
+# DB_CONNECTION=sqlite
+# DB_DATABASE=
 
-SESSION_DRIVER=database
-SESSION_LIFETIME=120
-SESSION_ENCRYPT=false
-SESSION_PATH=/
-SESSION_DOMAIN=null
+# Option 2: MySQL (Recommended for development and production)
+# Ensure your MySQL server is running and the database exists.
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=vendaaki_db
+DB_USERNAME=sail # Default for Laravel Sail, change if using local MySQL (e.g., root)
+DB_PASSWORD=password # Default for Laravel Sail, change if using local MySQL
 
-BROADCAST_CONNECTION=log
-FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
+# --------------------------------------------------------------------------
+# Cache, Session, Queue Drivers
+# --------------------------------------------------------------------------
+# For initial setup or simple environments, 'file' and 'sync' are safe defaults.
+# For production, consider 'redis' or 'memcached' for cache/session,
+# and 'database' or 'redis' for queues (requires running migrations for 'database' queue).
 
-CACHE_STORE=database
-CACHE_PREFIX=
+CACHE_STORE=file
+SESSION_DRIVER=file
+QUEUE_CONNECTION=sync # For 'database' queue, run migrations first.
 
-MEMCACHED_HOST=127.0.0.1
+# If using Redis:
+# REDIS_CLIENT=phpredis
+# REDIS_HOST=127.0.0.1
+# REDIS_PASSWORD=null
+# REDIS_PORT=6379
+# REDIS_DB=0 # For default Redis connection
+# REDIS_CACHE_DB=1 # For cache if using a separate Redis DB for cache
 
-REDIS_CLIENT=phpredis
-REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
-REDIS_PORT=6379
-
-MAIL_MAILER=log
-MAIL_SCHEME=null
-MAIL_HOST=127.0.0.1
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_FROM_ADDRESS="hello@example.com"
+# --------------------------------------------------------------------------
+# Mail Configuration
+# --------------------------------------------------------------------------
+MAIL_MAILER=log # For local development, logs emails to storage/logs/laravel.log
+# For production, use 'smtp', 'ses', 'mailgun', 'postmark', etc.
+# Example for Mailpit (local SMTP testing server):
+# MAIL_HOST=mailpit
+# MAIL_PORT=1025
+# MAIL_USERNAME=null
+# MAIL_PASSWORD=null
+# MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="hello@vendaaki.pt"
 MAIL_FROM_NAME="${APP_NAME}"
 
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_DEFAULT_REGION=us-east-1
-AWS_BUCKET=
-AWS_USE_PATH_STYLE_ENDPOINT=false
+# --------------------------------------------------------------------------
+# Broadcasting, Filesystem (Defaults are usually fine for starting)
+# --------------------------------------------------------------------------
+BROADCAST_CONNECTION=log # Default, can be 'pusher', 'redis', etc. for real-time features
+FILESYSTEM_DISK=local # Default, see config/filesystems.php for more options (e.g., s3)
 
+# --------------------------------------------------------------------------
+# Application Specifics
+# --------------------------------------------------------------------------
+APP_LOCALE=pt_PT # Set your application's primary locale
+APP_FALLBACK_LOCALE=en # Locale to use if APP_LOCALE translations are missing
+APP_FAKER_LOCALE=pt_PT # For generating fake data in Portuguese
+
+BCRYPT_ROUNDS=12
+PHP_CLI_SERVER_WORKERS=4 # For `php artisan serve` in PHP 8+
+APP_MAINTENANCE_DRIVER=file # Driver for maintenance mode
+CACHE_PREFIX=vendaaki_cache # Prefix for cache keys to avoid collisions
+
+# AWS Credentials (if using S3, SES, etc.)
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=us-east-1
+# AWS_BUCKET=
+# AWS_USE_PATH_STYLE_ENDPOINT=false
+
+# Vite specific (usually auto-populated or for advanced use)
 VITE_APP_NAME="${APP_NAME}"
+# VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}" # If using Pusher for broadcasting
+# VITE_PUSHER_HOST="${PUSHER_HOST}"
+# VITE_PUSHER_PORT="${PUSHER_PORT}"
+# VITE_PUSHER_SCHEME="${PUSHER_SCHEME}"
+# VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"


### PR DESCRIPTION
- Added BreezeServiceProvider to bootstrap/providers.php
- Configured .env.example with SQLite settings for sandbox and MySQL for production
- Added laravel/breeze to composer.json (require-dev)
- Note: Breeze installation blocked due to .env persistence issues in sandbox; APP_KEY generation and Artisan commands cannot proceed reliably