### PR TITLE
feat: Add migration and model for ads table

### DIFF
--- a/vendaaki/app/Models/Ad.php
+++ b/vendaaki/app/Models/Ad.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Ad extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'category_id',
+        'title',
+        'slug',
+        'description',
+        'condition',
+        'ad_type',
+        'price',
+        'starting_bid',
+        'current_bid',
+        'bid_increment',
+        'buy_now_price',
+        'auction_ends_at',
+        'location_city',
+        'location_postal_code',
+        'accepts_pickup',
+        'shipping_cost',
+        'status',
+        'views_count',
+        'is_promoted_until',
+        'promoted_by_share',
+        'published_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+        'starting_bid' => 'decimal:2',
+        'current_bid' => 'decimal:2',
+        'bid_increment' => 'decimal:2',
+        'buy_now_price' => 'decimal:2',
+        'shipping_cost' => 'decimal:2',
+        'auction_ends_at' => 'datetime',
+        'accepts_pickup' => 'boolean',
+        'promoted_by_share' => 'boolean',
+        'is_promoted_until' => 'datetime',
+        'published_at' => 'datetime',
+        'expires_at' => 'datetime',
+        // Enums são tratados como strings por defeito, o que é aceitável.
+        // Para PHP 8.1+ Enums, poderíamos fazer:
+        // 'condition' => \App\Enums\AdConditionEnum::class,
+        // 'ad_type' => \App\Enums\AdTypeEnum::class,
+        // 'status' => \App\Enums\AdStatusEnum::class,
+    ];
+
+    /**
+     * Get the user (seller) that owns the ad.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the category that the ad belongs to.
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    /**
+     * Get the images for the ad.
+     */
+    public function images(): HasMany
+    {
+        // Assumindo que teremos um modelo AdImage
+        return $this->hasMany(AdImage::class);
+    }
+
+    /**
+     * Get the bids for the ad (if it's an auction).
+     */
+    public function bids(): HasMany
+    {
+        // Assumindo que teremos um modelo Bid
+        return $this->hasMany(Bid::class);
+    }
+}

--- a/vendaaki/database/migrations/2025_06_26_074929_create_ads_table.php
+++ b/vendaaki/database/migrations/2025_06_26_074929_create_ads_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade'); // Vendedor
+            $table->foreignId('category_id')->constrained('categories')->onDelete('restrict'); // Categoria principal
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('description');
+            $table->enum('condition', ['new', 'used_like_new', 'used_good', 'used_fair']);
+            $table->enum('ad_type', ['fixed_price', 'auction', 'hybrid']);
+            $table->decimal('price', 10, 2)->nullable(); // Preço para venda a preço fixo ou preço "Comprar Já" no híbrido
+            $table->decimal('starting_bid', 10, 2)->nullable(); // Lance inicial para leilões
+            $table->decimal('current_bid', 10, 2)->nullable(); // Lance atual (para leilões)
+            $table->decimal('bid_increment', 8, 2)->nullable()->default(1.00); // Incremento mínimo para leilões
+            $table->decimal('buy_now_price', 10, 2)->nullable(); // Preço para "Comprar Já" em leilões híbridos
+            $table->timestamp('auction_ends_at')->nullable(); // Data e hora de fim do leilão
+            $table->string('location_city', 100)->nullable();
+            $table->string('location_postal_code', 20)->nullable();
+            $table->boolean('accepts_pickup')->default(true);
+            $table->decimal('shipping_cost', 8, 2)->nullable();
+            $table->enum('status', ['active', 'pending_approval', 'sold', 'expired', 'draft', 'rejected', 'deleted'])->default('draft');
+            $table->unsignedInteger('views_count')->default(0);
+            $table->timestamp('is_promoted_until')->nullable();
+            $table->boolean('promoted_by_share')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('expires_at')->nullable(); // Data de expiração do anúncio (se aplicável)
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ads');
+    }
+};


### PR DESCRIPTION
- Creates the migration for the 'ads' table with all specified fields, including foreign keys for user_id and category_id.
- Creates the Eloquent model Ad.php with appropriate $fillable and $casts attributes.
- Defines basic relationships in Ad.php: user (seller), category, images, and bids (target models AdImage and Bid to be created later).

Note: Migrations have not been run in the sandbox environment due to MySQL unavailability.