### PR TITLE
feat: Add migration and model for ad_images table

### DIFF
--- a/vendaaki/app/Models/AdImage.php
+++ b/vendaaki/app/Models/AdImage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AdImage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'image_path',
+        'is_cover',
+        'order',
+    ];
+
+    protected $casts = [
+        'is_cover' => 'boolean',
+    ];
+
+    /**
+     * Get the ad that the image belongs to.
+     */
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+}

--- a/vendaaki/database/migrations/2025_06_26_093653_create_ad_images_table.php
+++ b/vendaaki/database/migrations/2025_06_26_093653_create_ad_images_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ad_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->onDelete('cascade');
+            $table->string('image_path');
+            $table->boolean('is_cover')->default(false);
+            $table->tinyInteger('order')->unsigned()->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ad_images');
+    }
+};


### PR DESCRIPTION
- Creates the migration for the 'ad_images' table with fields for ad_id (FK to ads), image_path, is_cover, and order.
- Defines 'onDelete('cascade')' for the ad_id foreign key.
- Creates the Eloquent model AdImage.php with appropriate $fillable and $casts attributes.
- Defines the 'ad' BelongsTo relationship in AdImage.php.

Note: Migrations have not been run in the sandbox environment.