### PR TITLE
feat: Add migration and model for bids table

### DIFF
--- a/vendaaki/app/Models/Bid.php
+++ b/vendaaki/app/Models/Bid.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Bid extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ad_id',
+        'user_id',
+        'amount',
+        'is_auto_bid',
+        'max_auto_bid_amount',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'max_auto_bid_amount' => 'decimal:2',
+        'is_auto_bid' => 'boolean',
+    ];
+
+    /**
+     * Get the ad that the bid belongs to.
+     */
+    public function ad(): BelongsTo
+    {
+        return $this->belongsTo(Ad::class);
+    }
+
+    /**
+     * Get the user that made the bid.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/vendaaki/database/migrations/2025_06_26_094312_create_bids_table.php
+++ b/vendaaki/database/migrations/2025_06_26_094312_create_bids_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bids', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ad_id')->constrained('ads')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade'); // Utilizador que fez o lance
+            $table->decimal('amount', 10, 2);
+            $table->boolean('is_auto_bid')->default(false); // Se foi um lance automático (proxy bid)
+            $table->decimal('max_auto_bid_amount', 10, 2)->nullable(); // Valor máximo para proxy bid
+            $table->timestamps();
+
+            // Index para otimizar consultas por ad_id e user_id
+            $table->index(['ad_id', 'created_at']);
+            $table->index(['user_id', 'ad_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bids');
+    }
+};


### PR DESCRIPTION
- Creates the migration for the 'bids' table with fields for ad_id, user_id, amount, is_auto_bid, and max_auto_bid_amount.
- Defines onDelete('cascade') for ad_id and user_id foreign keys.
- Adds indexes for common query patterns on ad_id, user_id, and created_at.
- Creates the Eloquent model Bid.php with $fillable and $casts attributes.
- Defines 'ad' and 'user' BelongsTo relationships in Bid.php.

Note: Migrations have not been run in the sandbox environment.